### PR TITLE
Proposed partial solution to #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Further information is already available at [Deutsche Telekom (German)](http://w
 | `mysql_hardening_chroot.automatic-sp-privileges` | 0 | [automatic_sp_privileges](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_automatic_sp_privileges)|
 | `mysql_hardening_options.secure-file-priv` | /tmp | [secure-file-priv](https://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_secure-file-priv)|
 | `mysql_allow_remote_root` | false | delete remote root users |
+| `mysql_check_root_password_presence` | true | check password setting |
 | `mysql_remove_anonymous_users` | true | remove users without authentication |
 | `mysql_remove_test_database` | true | remove test database |
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ mysql_root_password: '-----====>SetR00tPa$$wordH3r3!!!<====-----'
 mysql_user_home: "{{ ansible_env.HOME}}"
 
 # ensure the following parameters are set properly
+mysql_check_root_password_presence: true
 mysql_remove_remote_root: true
 mysql_remove_anonymous_users: true
 mysql_remove_test_database: true

--- a/tasks/mysql_secure_installation.yml
+++ b/tasks/mysql_secure_installation.yml
@@ -22,6 +22,7 @@
     - '::1'
     - '127.0.0.1'
     - 'localhost'
+  when: mysql_check_root_password_presence
 
 - name: install .my.cnf with credentials
   template: src=my.cnf.j2 dest={{mysql_user_home}}/.my.cnf 


### PR DESCRIPTION
`mysql_user` invocations by a non privileged user in sudo/become mode have inferred chicken/egg problem of my.cnf generation.

In cases where there are other user generation, it makes sense to separate root pw setting and hardening.
