### PR TITLE
- renamed 'mysql_hardening_mysql_conf' var to 'mysql_hardening_mysql_…

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This hardening role installs the hardening but expects an existing installation 
 - `mysql_hardening_enabled: yes` role is enabled by default and can be disabled without removing it from a playbook. You can use conditional variable, for example: `mysql_hardening_enabled: "{{ true if mysql_enabled else false }}"`
 - `mysql_hardening_user: 'mysql'` The user that mysql runs as.
 - `mysql_datadir: '/var/lib/mysql'` The MySQL data directory
-- `mysql_hardening_hardening_conf: '/etc/mysql/conf.d/hardening.cnf'` The path to the configuration file where the hardening will be performed
+- `mysql_hardening_mysql_hardening_conf_file: '/etc/mysql/conf.d/hardening.cnf'` The path to the configuration file where the hardening will be performed
 
 ## Security Options
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ mysql_hardening_enabled: yes
 mysql_hardening_user: 'mysql'
 mysql_hardening_group: 'root'
 mysql_datadir: '/var/lib/mysql'
-mysql_hardening_hardening_conf: '{{mysql_hardening_mysql_conf_dir}}/hardening.cnf'
+mysql_hardening_mysql_hardening_conf_file: '{{mysql_hardening_mysql_confd_dir}}/hardening.cnf'
 # You have to change this to your own strong enough mysql root password
 mysql_root_password: '-----====>SetR00tPa$$wordH3r3!!!<====-----'
 # There .my.cnf with mysql root credentials will be installed 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ mysql_hardening_enabled: yes
 mysql_hardening_user: 'mysql'
 mysql_hardening_group: 'root'
 mysql_datadir: '/var/lib/mysql'
-mysql_hardening_hardening_conf: '/etc/mysql/conf.d/hardening.cnf'
+mysql_hardening_hardening_conf: '{{mysql_hardening_mysql_conf_dir}}/hardening.cnf'
 # You have to change this to your own strong enough mysql root password
 mysql_root_password: '-----====>SetR00tPa$$wordH3r3!!!<====-----'
 # There .my.cnf with mysql root credentials will be installed 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -7,7 +7,7 @@
   file: path='{{mysql_datadir}}' state=directory owner='{{mysql_hardening_user}}' group='{{mysql_hardening_user}}'
 
 - name: check mysql configuration-directory exists and has right permissions
-  file: path='{{mysql_hardening_mysql_conf_dir}}' state=directory owner='{{mysql_hardening_user}}' group='{{mysql_hardening_group}}' mode=0470
+  file: path='{{mysql_hardening_mysql_conf_dir}}' state=directory owner='{{mysql_hardening_user}}' group='{{mysql_hardening_group}}' mode=0570
 
 - name: check include-dir directive is present in my.cnf
   lineinfile: dest='{{mysql_hardening_mysql_conf_file}}' line='!includedir {{mysql_hardening_mysql_conf_dir}}' insertafter='EOF' state=present backup=yes

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,16 +1,16 @@
 ---
 
 - name: protect my.cnf
-  file: path='{{mysql_hardening_mysql_conf}}' mode=0600 owner=root group=root follow=yes
+  file: path='{{mysql_hardening_mysql_conf_file}}' mode=0600 owner=root group=root follow=yes
 
 - name: ensure permissions on mysql-datadir are correct
   file: path='{{mysql_datadir}}' state=directory owner='{{mysql_hardening_user}}' group='{{mysql_hardening_user}}'
 
 - name: check mysql configuration-directory exists and has right permissions
-  file: path='/etc/mysql/conf.d' state=directory owner='{{mysql_hardening_user}}' group='{{mysql_hardening_group}}' mode=0470
+  file: path='{{mysql_hardening_mysql_conf_dir}}' state=directory owner='{{mysql_hardening_user}}' group='{{mysql_hardening_group}}' mode=0470
 
 - name: check include-dir directive is present in my.cnf
-  lineinfile: dest='{{mysql_hardening_mysql_conf}}' line='!includedir /etc/mysql/conf.d/' insertafter='EOF' state=present backup=yes
+  lineinfile: dest='{{mysql_hardening_mysql_conf_file}}' line='!includedir {{mysql_hardening_mysql_conf_dir}}' insertafter='EOF' state=present backup=yes
   notify: restart mysql
 
 - name: apply hardening configuration

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,18 +1,18 @@
 ---
 
 - name: protect my.cnf
-  file: path='{{mysql_hardening_mysql_conf_file}}' mode=0600 owner=root group=root follow=yes
+  file: path='{{mysql_hardening_mysql_conf_file}}' mode=0400 owner='{{mysql_hardening_user}}' group='{{mysql_hardening_group}}' follow=yes
 
 - name: ensure permissions on mysql-datadir are correct
   file: path='{{mysql_datadir}}' state=directory owner='{{mysql_hardening_user}}' group='{{mysql_hardening_user}}'
 
 - name: check mysql configuration-directory exists and has right permissions
-  file: path='{{mysql_hardening_mysql_conf_dir}}' state=directory owner='{{mysql_hardening_user}}' group='{{mysql_hardening_group}}' mode=0570
+  file: path='{{mysql_hardening_mysql_confd_dir}}' state=directory owner='{{mysql_hardening_user}}' group='{{mysql_hardening_group}}' mode=0570
 
 - name: check include-dir directive is present in my.cnf
-  lineinfile: dest='{{mysql_hardening_mysql_conf_file}}' line='!includedir {{mysql_hardening_mysql_conf_dir}}' insertafter='EOF' state=present backup=yes
+  lineinfile: dest='{{mysql_hardening_mysql_conf_file}}' line='!includedir {{mysql_hardening_mysql_confd_dir}}' insertafter='EOF' state=present backup=yes
   notify: restart mysql
 
 - name: apply hardening configuration
-  template: src='hardening.cnf.j2' dest='{{mysql_hardening_hardening_conf}}' owner='{{mysql_hardening_user}}' group='{{mysql_hardening_group}}' mode=0460
+  template: src='hardening.cnf.j2' dest='{{mysql_hardening_mysql_hardening_conf_file}}' owner='{{mysql_hardening_user}}' group='{{mysql_hardening_group}}' mode=0460
   notify: restart mysql

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,2 +1,3 @@
 mysql_daemon: mysql
-mysql_hardening_mysql_conf: '/etc/mysql/my.cnf'
+mysql_hardening_mysql_conf_file: '/etc/mysql/my.cnf'
+mysql_hardening_mysql_conf_dir: '/etc/mysql/conf.d'

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,3 @@
 mysql_daemon: mysql
 mysql_hardening_mysql_conf_file: '/etc/mysql/my.cnf'
-mysql_hardening_mysql_conf_dir: '/etc/mysql/conf.d'
+mysql_hardening_mysql_confd_dir: '/etc/mysql/conf.d'

--- a/vars/Oracle Linux.yml
+++ b/vars/Oracle Linux.yml
@@ -1,2 +1,3 @@
 mysql_daemon: mysqld
-mysql_hardening_mysql_conf: '/etc/my.cnf'
+mysql_hardening_mysql_conf_file: '/etc/my.cnf'
+mysql_hardening_mysql_conf_dir: '/etc/my.cnf.d'

--- a/vars/Oracle Linux.yml
+++ b/vars/Oracle Linux.yml
@@ -1,3 +1,3 @@
 mysql_daemon: mysqld
 mysql_hardening_mysql_conf_file: '/etc/my.cnf'
-mysql_hardening_mysql_conf_dir: '/etc/my.cnf.d'
+mysql_hardening_mysql_confd_dir: '/etc/my.cnf.d'

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,2 +1,3 @@
 mysql_daemon: mysqld
-mysql_hardening_mysql_conf: '/etc/my.cnf'
+mysql_hardening_mysql_conf_file: '/etc/my.cnf'
+mysql_hardening_mysql_conf_dir: '/etc/my.cnf.d'

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,3 +1,3 @@
 mysql_daemon: mysqld
 mysql_hardening_mysql_conf_file: '/etc/my.cnf'
-mysql_hardening_mysql_conf_dir: '/etc/my.cnf.d'
+mysql_hardening_mysql_confd_dir: '/etc/my.cnf.d'


### PR DESCRIPTION
- renamed 'mysql_hardening_mysql_conf' var to 'mysql_hardening_mysql_conf_file'
- introduced 'mysql_hardening_mysql_conf_dir' variable
- set default value of 'mysql_hardening_mysql_conf_dir' variable for RedHat, OracleLinux, Debian
- changed default hardcoded full path in 'mysql_hardening_hardening_conf' var to be based on 'mysql_hardening_mysql_conf_dir' var
