### PR TITLE
Add CentOS7 with MariaDB support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -31,6 +31,10 @@ platforms:
   driver_config:
     box: opscode-centos-6.5
     box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
+- name: centos-7.2
+  driver_config:
+    box: opscode-centos-7.2
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.2_chef-provisionerless.box
 - name: oracle-6.4
   driver_config:
     box: oracle-6.4

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,8 @@
 - name: add the OS specific variables
   include_vars: "{{ item }}"
   with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+    - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
     - "{{ ansible_os_family }}.yml"
   tags: always

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,10 @@
 ---
 
 - name: add the OS specific variables
-  include_vars: "{{ ansible_os_family }}.yml"
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
+    - "{{ ansible_os_family }}.yml"
   tags: always
 
 - include: configure.yml

--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -1,0 +1,3 @@
+mysql_daemon: mariadb
+mysql_hardening_mysql_conf_file: '/etc/my.cnf'
+mysql_hardening_mysql_confd_dir: '/etc/my.cnf.d'


### PR DESCRIPTION
This PR adds a configuration for RedHat 7-based servers that specifies "mariadb" as the value for mysql_daemon.  

There is also Test Kitchen test for CentOS 7.2, which is passes, though I would point out that other tests (for Ubuntu and CentOS 6.x) are failing even before this PR -- at least on my setup.

This addresses issue #23. 