### PR TITLE
Fix ansible.cfg settings

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -8,7 +8,8 @@
 # finds first
 
 [defaults]
-ansible_managed = Ansible managed: {file} modified on %Y-%m-%d by {uid} on {host}
+ansible_managed = Ansible managed: {file} modified by {uid} on {host}
+roles_path = /vagrant
 
-role_path = /vagrant
+[ssh_connection]
 scp_if_ssh = True


### PR DESCRIPTION
- using `%Y-%m-%d` in `ansible_managed` message is not recommended
as deploying from a new git checkout will change the `ansible_managed`
string in the template and Ansible will report the template file as changed
(see http://docs.ansible.com/ansible/intro_configuration.html#ansible-managed )
- no such setting called `role_path` (see
http://docs.ansible.com/ansible/intro_configuration.html )
- `scp_if_ssh` should be under `[ssh_connection]` header