### PR TITLE
Add test support for Debian Buster

### DIFF
--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -40,6 +40,9 @@ platforms:
 - name: debian-9
   driver_config:
     box: bento/debian-9
+- name: debian-10
+  driver_config:
+    box: bento/debian-10
 - name: amazon
   driver_config:
     box: bento/amazonlinux-2

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -59,6 +59,14 @@ platforms:
     provision_command:
       - apt install -y systemd-sysv
       - systemctl enable ssh.service
+- name: debian10-ansible-latest
+  driver:
+    image: rndmh3ro/docker-debian10-ansible:latest
+    platform: debian
+    run_command: /sbin/init
+    provision_command:
+      - apt install -y systemd-sysv
+      - systemctl enable ssh.service
 - name: amazon-ansible-latest
   driver:
     image: rndmh3ro/docker-amazon-ansible:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,11 @@ env:
 #    init: /lib/systemd/systemd
 #    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 
+  - distro: debian10
+    version: latest
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+
   - distro: amazon
     init: /lib/systemd/systemd
     version: latest


### PR DESCRIPTION
This pull request adds testing for Debian Buster and fixes #37 

- [x] kitchen with vagrant 
- [x] kitchen with docker
- [x] travis