### PR TITLE
use bool filter on bare variable to address Ansible 2.8 deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,12 +10,12 @@
   tags: always
 
 - include: configure.yml
-  when: mysql_hardening_enabled
+  when: mysql_hardening_enabled | bool
   tags:
     - mysql_hardening
 
 - include: mysql_secure_installation.yml
-  when: mysql_hardening_enabled
+  when: mysql_hardening_enabled | bool
   tags:
     - mysql_hardening
     - mysql_secure_installation


### PR DESCRIPTION
Ansible 2.8 now displays a [deprecation warning](https://github.com/ansible/ansible/issues/34591) over the use of bare variables in conditionals. I'm not quite sure why [the porting guide](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.8.html) doesn't reflect it yet, but here is the [pull request](https://github.com/ansible/ansible/pull/60943) that adds documentation for the warning.

In short, 

    when: mysql_hardening_enabled

needs to be

    when: mysql_hardening_enabled | bool