### PR TITLE
Use python3-mysqldb for Ubuntu 20.04

### DIFF
--- a/tasks/mysql_secure_installation.yml
+++ b/tasks/mysql_secure_installation.yml
@@ -5,11 +5,16 @@
 #  package: pkg=python-mysqldb state=present
 
 
-- name: Install MySQL-python for Ansible
-  apt: name=python-mysqldb state=present
-  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+- name: Install python3-mysqldb for Ansible
+  apt: name=python3-mysqldb state=present
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version >= '20.04'
 
 - name: Install python-mysqldb for Ansible
+  apt: name=python-mysqldb state=present
+  when: ansible_distribution == 'Debian' or
+        (ansible_distribution == 'Ubuntu' and ansible_distribution_version < '20.04')
+
+- name: Install MySQL-python for Ansible
   yum: name=MySQL-python state=present
   when: ansible_os_family == 'RedHat' or ansible_os_family == 'Oracle Linux'
 


### PR DESCRIPTION
Ubuntu 20.04 doesn't support Python 2 by default as it is already expired. So `python3-mysqldb` is mandatory instead of `python-mysqldb`
