### PR TITLE
Use mysql_query module instead of temporary files

### DIFF
--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -13,6 +13,7 @@ provisioner:
   roles_path: ../ansible-mysql-hardening/
   playbook: default.yml
   requirements_path: requirements.yml
+  requirements_collection_path: requirements.yml
   sudo_command: 'sudo -E -H'
 
 transport:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,6 +22,9 @@ provisioner:
   http_proxy: <%= ENV['http_proxy'] || nil %>
   https_proxy: <%= ENV['https_proxy'] || nil %>
   requirements_path: requirements.yml
+  requirements_collection_path: requirements.yml
+#  ansible_cfg_path: ansible.cfg
+#  ansible_cfg_overwrite: true
   sudo_command: 'sudo -E -H'
   playbook: tests/test.yml
   galaxy_ignore_certs: true

--- a/Gemfile
+++ b/Gemfile
@@ -3,13 +3,13 @@
 source 'https://rubygems.org'
 
 group :integration do
-  gem 'test-kitchen', '~> 1.0'
+  gem 'test-kitchen'
   gem 'kitchen-ansible'
   gem 'kitchen-vagrant'
   gem 'kitchen-inspec'
-  gem 'kitchen-sharedtests', '~> 0.2.0'
+  gem 'kitchen-sharedtests'
   gem 'kitchen-sync'
-  gem 'kitchen-transport-rsync'
   gem 'kitchen-docker'
-  gem 'inspec', '~> 3'
+  gem 'inspec'
+  gem 'aws-sdk'
 end

--- a/README.md
+++ b/README.md
@@ -18,22 +18,24 @@ This role focuses on security configuration of MySQL. Therefore you can add this
 
 Install the role with ansible-galaxy:
 
-```
+```sh
 ansible-galaxy install dev-sec.mysql-hardening
 ```
 
 ### Example Playbook
 
-    - hosts: localhost
-      roles:
-        - dev-sec.mysql-hardening
+```yml
+- hosts: localhost
+  roles:
+    - dev-sec.mysql-hardening
+```
 
 This hardening role installs the hardening but expects an existing installation of MySQL, MariaDB or Percona. Please ensure that the following variables are set accordingly:
 
-- `mysql_hardening_enabled: yes` role is enabled by default and can be disabled without removing it from a playbook. You can use conditional variable, for example: `mysql_hardening_enabled: "{{ true if mysql_enabled else false }}"`
-- `mysql_hardening_user: 'mysql'` The user that mysql runs as.
-- `mysql_datadir: '/var/lib/mysql'` The MySQL data directory
-- `mysql_hardening_mysql_hardening_conf_file: '/etc/mysql/conf.d/hardening.cnf'` The path to the configuration file where the hardening will be performed
+* `mysql_hardening_enabled: yes` role is enabled by default and can be disabled without removing it from a playbook. You can use conditional variable, for example: `mysql_hardening_enabled: "{{ true if mysql_enabled else false }}"`
+* `mysql_hardening_user: 'mysql'` The user that mysql runs as.
+* `mysql_datadir: '/var/lib/mysql'` The MySQL data directory
+* `mysql_hardening_mysql_hardening_conf_file: '/etc/mysql/conf.d/hardening.cnf'` The path to the configuration file where the hardening will be performed
 
 ## Role Variables
 
@@ -87,27 +89,32 @@ You can also use vagrant and Virtualbox or VMWare to run tests locally. You will
 
 Next install test-kitchen:
 
-```bash
+```sh
 # Install dependencies
 gem install bundler
 bundle install
 ```
 
 ### Testing with Docker
-```
+
+```sh
+# list all available machines
+bundle exec kitchen list
+
 # fast test on one machine
-bundle exec kitchen test default-ubuntu-1204
+bundle exec kitchen test mysql-centos7-ansible-latest
 
 # test on all machines
 bundle exec kitchen test
 
 # for development
-bundle exec kitchen create default-ubuntu-1204
-bundle exec kitchen converge default-ubuntu-1204
+bundle exec kitchen create mysql-centos7-ansible-latest
+bundle exec kitchen converge mysql-centos7-ansible-latest
 ```
 
 ### Testing with Virtualbox
-```
+
+```sh
 # fast test on one machine
 KITCHEN_YAML=".kitchen.vagrant.yml" bundle exec kitchen test default-ubuntu-1404
 
@@ -118,6 +125,7 @@ KITCHEN_YAML=".kitchen.vagrant.yml" bundle exec kitchen test
 KITCHEN_YAML=".kitchen.vagrant.yml" bundle exec kitchen create default-ubuntu-1404
 KITCHEN_YAML=".kitchen.vagrant.yml" bundle exec kitchen converge default-ubuntu-1404
 ```
+
 For more information see [test-kitchen](http://kitchen.ci/docs/getting-started)
 
 ## License and Author

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -10,6 +10,7 @@
 [defaults]
 ansible_managed = Ansible managed: {file} modified by {uid} on {host}
 roles_path = /vagrant
+collections_paths = /tmp/kitchen/collections
 
 [ssh_connection]
 scp_if_ssh = True

--- a/files/mysql_remove_remote_root.sql
+++ b/files/mysql_remove_remote_root.sql
@@ -1,1 +1,0 @@
-DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,2 +1,6 @@
 ---
-- src: geerlingguy.mysql
+collections:
+  - community.mysql
+
+roles:
+  - src: geerlingguy.mysql

--- a/tasks/mysql_secure_installation.yml
+++ b/tasks/mysql_secure_installation.yml
@@ -35,22 +35,8 @@
     host_all: true
   when: mysql_remove_anonymous_users
 
-- name: copy mysql_remove_remote_root
-  copy:
-    src: '{{ item }}.sql'
-    dest: '/tmp/{{ item }}.sql'
-    mode: '0400'
-  with_items:
-    - mysql_remove_remote_root
+- name: remove remote root
+  community.mysql.mysql_query:
+    query:
+      - DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1')
   when: mysql_remove_remote_root
-  changed_when: false
-
-- name: apply mysql_remove_remote_root
-  mysql_db:
-    name: 'mysql'
-    state: import
-    target: '/tmp/{{ item }}.sql'
-  with_items:
-    - mysql_remove_remote_root
-  when: mysql_remove_remote_root
-  changed_when: false

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -12,7 +12,7 @@
     - name: install procps for debian systems
       apt:
         name: procps
-        state: installed
+        state: present
         update_cache: true
       when: ansible_distribution == 'Debian'
     - name: set logfile according to OS
@@ -23,6 +23,20 @@
       set_fact:
         mysql_log_error: "/var/log/mysqld.log"
       when: ansible_os_family == "RedHat"
+    - name: Install pip according to OS
+      apt:
+        name: python-pip
+        state: present
+      when: ansible_os_family == 'Debian'
+    - name: Install pip according to OS
+      yum:
+        name: python-pip
+        state: present
+      when: ansible_os_family == 'RedHat'
+    - name: Make sure pymysql is present
+      pip:
+        name: pymysql
+        state: present
   vars:
     overwrite_global_mycnf: false
     mysql_root_password: iloverandompasswordsbutthiswilldo
@@ -32,3 +46,5 @@
   roles:
     - geerlingguy.mysql
     - ansible-mysql-hardening
+  collections:
+    - community.mysql


### PR DESCRIPTION
update Gems, fix test playbook, update README

Fixes https://github.com/dev-sec/ansible-mysql-hardening/issues/52

sample run 
```
root@0cdf3aa7badd:/ ansible-playbook play.yaml

PLAY [localhost] ****************************************************************************************************************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************************************************************************************************************
....

PLAY RECAP **********************************************************************************************************************************************************************************************************
localhost                  : ok=16   changed=7    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

root@0cdf3aa7badd:/ cat play.yaml
- hosts: localhost
  roles:
    - /ansible-mysql-hardening
  vars:
    mysql_hardening_enabled: yes
    mysql_hardening_user: 'root'
    mysql_datadir: '/var/lib/mysql'
```

Converge runs with mysql-centos7-ansible-latest

```
       PLAY RECAP *********************************************************************
       localhost                  : ok=49   changed=15   unreachable=0    failed=0    skipped=25   rescued=0    ignored=0

       Downloading files from <mysql-centos7-ansible-latest>
       Finished converging <mysql-centos7-ansible-latest> (1m3.29s).
-----> Test Kitchen is finished. (1m3.99s)
```


Geerlingguy role has some issues with other distros, like ubuntu and debian.