### PR TITLE
Run ansible-lint via github action

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,0 +1,14 @@
+name: Ansible Lint
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    # Important: This sets up your GITHUB_WORKSPACE environment variable
+    - uses: actions/checkout@v2
+    - name: Lint Ansible Playbook
+      uses: ansible/ansible-lint-action@master
+      with:
+        targets: ""

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # mysql-hardening (Ansible role)
 
 [![Build Status](http://img.shields.io/travis/dev-sec/ansible-mysql-hardening.svg)][1]
+![Ansible Lint](https://github.com/dev-sec/ansible-mysql-hardening/workflows/Ansible%20Lint/badge.svg?branch=master)
 [![Ansible Galaxy](https://img.shields.io/badge/galaxy-mysql--hardening-660198.svg)][3]
 
 ## Description

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,9 +6,11 @@
       apt:
         update_cache: true
       when: ansible_os_family == 'Debian'
-    - file:
+    - name: Create mysql directory if it does not exist
+      file:
         path: "/etc/mysql"
         state: directory
+        mode: 0755
     - name: install procps for debian systems
       apt:
         name: procps


### PR DESCRIPTION
@rndmh3ro 
As you're already in transition to github-actions I thought it would be good to run the ansible-linting via the github-actions as well, as it appears that there are some issues with travis-ci and ansible-lint.